### PR TITLE
SOC-627: allow to use define variables other than in scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Will output:
 ```
 
 Note there is no entry for `white` because the variable does not exist in the file, and there is no entry for `black` because there is no description in the DSS block.
+If you pass `true` flag to the constructor it will include variables that does not exist in the file, i.e. there would be entry for a `white` in output.
 
 [Documented Style Sheets]:https://github.com/darcyclarke/DSS
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Will output:
 ```
 
 Note there is no entry for `white` because the variable does not exist in the file, and there is no entry for `black` because there is no description in the DSS block.
-If you pass `true` flag to the constructor it will include variables that does not exist in the file, i.e. there would be entry for a `white` in output.
+If you pass `false` flag to the constructor it will include variables that does not exist in the file, i.e. there would be entry for a `white` in output.
 
 [Documented Style Sheets]:https://github.com/darcyclarke/DSS
 

--- a/index.js
+++ b/index.js
@@ -7,10 +7,10 @@ module.exports = dssVariableParser;
 /**
  * Get parser to extract "@variable {name} - {description}"
  *
- * @param {object} file - The file to extract the variable values from
+ * @param {boolean} loose - should we ignore presence of variable in a scope?
  * @return {function} A DSS parser
  */
-function dssVariableParser() {
+function dssVariableParser(loose) {
 
     var fileVariables = {},
         fileVariablesRx = /^[\$|@]([a-zA-Z0-9_-]+):([^\;]+)\;/gim,
@@ -31,7 +31,7 @@ function dssVariableParser() {
         // Extract variable name and description from comment block
         tokens = line.split(lineSplitRx, 2);
         name = tokens[0].trim();
-        if (variables.hasOwnProperty(name)) {
+        if (variables.hasOwnProperty(name) || loose) {
             return {
                 name: name,
                 // Description is line with variable name and any delimiter replaced

--- a/index.js
+++ b/index.js
@@ -7,16 +7,20 @@ module.exports = dssVariableParser;
 /**
  * Get parser to extract "@variable {name} - {description}"
  *
- * @param {boolean} loose - should we ignore presence of variable in a scope?
+ * @param {boolean} [strict=true] - ignore definitions of undefined variables
  * @return {function} A DSS parser
  */
-function dssVariableParser(loose) {
+function dssVariableParser(strict) {
 
     var fileVariables = {},
         fileVariablesRx = /^[\$|@]([a-zA-Z0-9_-]+):([^\;]+)\;/gim,
         lineSplitRx = /(\s(-\s)?)/,
         variables = {},
         match, hash, tokens, name;
+
+    if (typeof strict === 'undefined') {
+        strict = true;
+    }
 
     return function(i, line, block, css) {
         // Extract all defined variables in this CSS file (once per file)
@@ -31,7 +35,7 @@ function dssVariableParser(loose) {
         // Extract variable name and description from comment block
         tokens = line.split(lineSplitRx, 2);
         name = tokens[0].trim();
-        if (variables.hasOwnProperty(name) || loose) {
+        if (variables.hasOwnProperty(name) || !strict) {
             return {
                 name: name,
                 // Description is line with variable name and any delimiter replaced

--- a/test/test.js
+++ b/test/test.js
@@ -19,6 +19,16 @@ describe('dss-variable-parser', function() {
         });
     });
 
+    it('should parse name and description from @variable, if variable is not defined', function(done) {
+        var css = '/**\n * @variable blue - Sky blue\n */';
+        dss.parser('variable', dssParserVariable(true));
+        dss.parse(css, {}, function(parsedDss) {
+            expect(parsedDss.blocks[0].variable.name).to.equal('blue');
+            expect(parsedDss.blocks[0].variable.description).to.equal('Sky blue');
+            done();
+        });
+    });
+
     it('should parse multiples @variable into an array', function(done) {
         var css = '/**\n * @variable blue - Sky blue\n  * @variable red\n*/\n$blue: #0000FF;\n$red: #FF0000;\n';
         dss.parser('variable', dssParserVariable());

--- a/test/test.js
+++ b/test/test.js
@@ -1,13 +1,11 @@
 'use strict';
 /* globals describe, it */
 var fs = require('fs');
+var dss = require('dss');
 var expect = require('chai').expect;
 var dssParserVariable = require('../');
-var dss = require('dss');
-
 
 describe('dss-variable-parser', function() {
-
     it('should parse name, value and description from @variable', function(done) {
         var css = '/**\n * @variable blue - Sky blue\n */\n$blue: #0000FF;\n';
         dss.parser('variable', dssParserVariable());
@@ -21,7 +19,7 @@ describe('dss-variable-parser', function() {
 
     it('should parse name and description from @variable, if variable is not defined', function(done) {
         var css = '/**\n * @variable blue - Sky blue\n */';
-        dss.parser('variable', dssParserVariable(true));
+        dss.parser('variable', dssParserVariable(false));
         dss.parse(css, {}, function(parsedDss) {
             expect(parsedDss.blocks[0].variable.name).to.equal('blue');
             expect(parsedDss.blocks[0].variable.description).to.equal('Sky blue');
@@ -128,5 +126,4 @@ describe('dss-variable-parser', function() {
             done();
         });
     });
-
 });


### PR DESCRIPTION
If `loose` flag is equal `true` then we're adding variables even if they do not exist in a scope of the file.
